### PR TITLE
Interrupts v2

### DIFF
--- a/Sources/Microprocessed/Interrupting.swift
+++ b/Sources/Microprocessed/Interrupting.swift
@@ -1,0 +1,26 @@
+//
+//  Interrupting.swift
+//  
+//
+//  Created by Nate Rivard on 10/07/2023.
+//
+
+import Foundation
+
+public enum InterruptStatus {
+    /// Device is not interrupting
+    case none
+
+    /// Device is interrupting and is non-maskable
+    case nonMaskableAssertion
+
+    /// Device is interrupting but is maskable
+    case maskableAssertion
+}
+
+/// Simple protocol that seeks to answer the question: are you holding either interrupt line low?
+/// ISR will be called repeatedly while _any_ device is holding a line low and interrupt conditions are met
+public protocol Interrupting {
+    /// Device returns an interrupt status
+    var interruptStatus: InterruptStatus { get }
+}

--- a/Sources/Microprocessed/Interrupting.swift
+++ b/Sources/Microprocessed/Interrupting.swift
@@ -12,10 +12,10 @@ public enum InterruptStatus {
     case none
 
     /// Device is interrupting and is non-maskable
-    case nonMaskableAssertion
+    case nonMaskable
 
     /// Device is interrupting but is maskable
-    case maskableAssertion
+    case maskable
 }
 
 /// Simple protocol that seeks to answer the question: are you holding either interrupt line low?

--- a/Tests/MicroprocessedTests/Instructions/BRK.swift
+++ b/Tests/MicroprocessedTests/Instructions/BRK.swift
@@ -16,4 +16,18 @@ final class BRKTests: SystemTests {
         XCTAssert(try mpu.pop() == status.rawValue)
         XCTAssert(try mpu.popWord() == returnAddress)
     }
+
+    func testBRKWithInterruptsDisabled() throws {
+        let returnAddress = mpu.registers.PC + 2
+        let irqAddress: UInt16 = 0xA5DF
+        let status: StatusFlags = [.isNegative, .didCarry, .didOverflow, .alwaysSet, .isSoftwareInterrupt, .interruptsDisabled]
+        try ram.write(toAddressStartingAt: Microprocessor.irqVector, word: irqAddress)
+        mpu.registers.SR = status.rawValue
+
+        try mpu.execute(0x00)
+        XCTAssert(mpu.registers.PC == irqAddress)
+        XCTAssert(mpu.registers.$SR.contains(.interruptsDisabled))
+        XCTAssert(try mpu.pop() == status.rawValue)
+        XCTAssert(try mpu.popWord() == returnAddress)
+    }
 }

--- a/Tests/MicroprocessedTests/InterruptTests.swift
+++ b/Tests/MicroprocessedTests/InterruptTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import Microprocessed
+
+final class InterruptTests: SystemTests {
+    var interruptor = Interruptor()
+
+    override var interruptors: [Interrupting] {
+        return [interruptor]
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try ram.write(toAddressStartingAt: Microprocessor.irqVector, word: 0xC000)
+        try ram.write(toAddressStartingAt: Microprocessor.nmiVector, word: 0xD000)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        interruptor.interruptStatus = .none
+    }
+
+    func testIRQ() throws {
+        /// irq handler that just calls RTI
+        try ram.write(to: 0xC000, data: 0x40)
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        interruptor.interruptStatus = .maskable
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0xC000)
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0x8000)
+        /// irq has not been de-asserted so we should re-enter irq handler
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0xC000)
+        interruptor.interruptStatus = .none
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0x8000)
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8001)
+    }
+
+    func testNMI() throws {
+        /// irq handler that just calls RTI
+        try ram.write(to: 0xD000, data: 0x40)
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        interruptor.interruptStatus = .nonMaskable
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0xD000)
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0x8000)
+        /// irq has not been de-asserted so we should re-enter irq handler
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0xD000)
+        interruptor.interruptStatus = .none
+        try mpu.tick()
+
+        XCTAssert(mpu.registers.PC == 0x8000)
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8001)
+    }
+
+    func testNMISupercedesIRQ() throws {
+        /// irq and nmi handlers just return
+        try ram.write(to: 0xC000, data: 0x40)
+        try ram.write(to: 0xD000, data: 0x40)
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        interruptor.interruptStatus = .maskable
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0xC000)
+        XCTAssert(mpu.interruptMask == [.irq])
+
+        interruptor.interruptStatus = .nonMaskable
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0xD000)
+        XCTAssert(mpu.interruptMask == [.irq, .nmi])
+
+        interruptor.interruptStatus = .none
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0xC000)
+        XCTAssert(mpu.interruptMask == [.irq])
+
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8000)
+        XCTAssert(mpu.interruptMask == [])
+
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8001)
+    }
+
+    func testIRQWithInterruptsDisabled() throws {
+        mpu.registers.setInterruptsDisabled()
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        interruptor.interruptStatus = .maskable
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8001)
+
+        mpu.registers.clearInterruptsDisabled()
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0xC000)
+    }
+
+    func testNMIWithInterruptsDisabled() throws {
+        mpu.registers.setInterruptsDisabled()
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        interruptor.interruptStatus = .nonMaskable
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0xD000)
+    }
+
+    func testWakeOnInterrupt() throws {
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        /// execute `WAI`
+        try mpu.execute(0xCB)
+        XCTAssert(mpu.registers.PC == 0x8001)
+        XCTAssert(mpu.runMode == .waitingForInterrupt)
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8001)
+
+        interruptor.interruptStatus = .maskable
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0xC000)
+        XCTAssert(mpu.runMode == .normal)
+    }
+
+    func testWakeOnInterruptWithInterruptsDisabled() throws {
+        mpu.registers.setInterruptsDisabled()
+        XCTAssert(mpu.registers.PC == 0x8000)
+
+        /// execute `WAI`
+        try mpu.execute(0xCB)
+        XCTAssert(mpu.registers.PC == 0x8001)
+        XCTAssert(mpu.runMode == .waitingForInterrupt)
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8001)
+
+        interruptor.interruptStatus = .maskable
+        try mpu.tick()
+        XCTAssert(mpu.registers.PC == 0x8002)
+        XCTAssert(mpu.runMode == .normal)
+    }
+}
+
+/// simple interruptor that allows direct setting of interrupt status
+final class Interruptor: Interrupting {
+    var interruptStatus: InterruptStatus = .none
+}

--- a/Tests/MicroprocessedTests/SystemTest.swift
+++ b/Tests/MicroprocessedTests/SystemTest.swift
@@ -5,12 +5,15 @@ class SystemTests: XCTestCase {
 
     var ram: MemoryAddressable = TestMemory()
     var mpu: Microprocessor!
+    var interruptors: [Interrupting] {
+        return []
+    }
 
     override func setUpWithError() throws {
         try super.setUpWithError()
 
         self.ram = TestMemory()
-        self.mpu = Microprocessor(memoryLayout: ram)
+        self.mpu = Microprocessor(memoryLayout: ram, interruptors: interruptors)
 
         try mpu.reset()
     }


### PR DESCRIPTION
Simulates more real-world interrupt handling:
* adds a new `Interrupting` protocol for devices to conform to
* register interrupting devices with `Microprocessor` when setting up (no hot-swapping!)
* devices are polled at the beginning of `tick()`